### PR TITLE
bumping the carbon-analytics, carbon-analytics-commons and carbon-data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,10 +480,10 @@
 		<carbon.deployment.version>4.7.0</carbon.deployment.version>
 		<carbon.multitenancy.version>4.5.3-SNAPSHOT</carbon.multitenancy.version>
 		<carbon.commons.version>4.5.4</carbon.commons.version>
-		<carbon.data.version>4.3.5-SNAPSHOT</carbon.data.version>
-		<carbon.analytics.version>1.0.6-SNAPSHOT</carbon.analytics.version>
+		<carbon.data.version>4.3.6-SNAPSHOT</carbon.data.version>
+		<carbon.analytics.version>1.1.1-SNAPSHOT</carbon.analytics.version>
 		<carbon.metrics.version>1.2.2</carbon.metrics.version>
-		<carbon.analytics.common.version>5.1.0-SNAPSHOT</carbon.analytics.common.version>
+		<carbon.analytics.common.version>5.1.1-SNAPSHOT</carbon.analytics.common.version>
 		<carbon.kernel.version>4.4.7</carbon.kernel.version>
 		<carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 


### PR DESCRIPTION
Bumped versions of carbon-analytics, carbon-data and carbon analytics commons, still the build will fail since the carbon-identity version 5.1.1-snapshot is not found in nexus. may be required to change to the identity framework.